### PR TITLE
Fixes several bugs with Search facets and results

### DIFF
--- a/src/components/Search/withSearch.jsx
+++ b/src/components/Search/withSearch.jsx
@@ -52,7 +52,7 @@ export default function withSearch(OriginalComponent, apiEndPoint) {
       this.state = {
         searchEngine: false,
         searchParams: props.defaultParams,
-        selectedFacets: [],
+        selectedFacets: props.selectedFacets || [],
         totalFacets: {},
         facetsResults: {},
         searchLink: '',
@@ -310,7 +310,8 @@ export default function withSearch(OriginalComponent, apiEndPoint) {
           activeFacet[0] === facet[0]
         ));
         const selected = selectedFacets.find((selectedFacet) => (
-          (selectedFacet[1].toLowerCase() === facet[0].toLowerCase()) && (selectedFacet[0].toLowerCase() === facetKey.toLowerCase())
+          (selectedFacet[1].toLowerCase() === facet[0].toLowerCase())
+          && (selectedFacet[0].toLowerCase() === facetKey.toLowerCase())
         ));
         if (selected || hasResults) {
           return facet;

--- a/src/components/Search/withSearch.jsx
+++ b/src/components/Search/withSearch.jsx
@@ -310,9 +310,8 @@ export default function withSearch(OriginalComponent, apiEndPoint) {
           activeFacet[0] === facet[0]
         ));
         const selected = selectedFacets.find((selectedFacet) => (
-          (selectedFacet[0] === facet[0]) && (selectedFacet[0] === facetKey)
+          (selectedFacet[1].toLowerCase() === facet[0].toLowerCase()) && (selectedFacet[0].toLowerCase() === facetKey.toLowerCase())
         ));
-
         if (selected || hasResults) {
           return facet;
         }

--- a/src/components/Search/withSearch.jsx
+++ b/src/components/Search/withSearch.jsx
@@ -242,6 +242,7 @@ export default function withSearch(OriginalComponent, apiEndPoint) {
     async handlePageSizeChange(event) {
       const { searchParams } = this.state;
       const pageSize = parseInt(event.target.value, 10);
+      searchParams.page = 1;
       searchParams.pageSize = parseInt(pageSize, 10);
       await this.fetchData();
     }
@@ -281,6 +282,7 @@ export default function withSearch(OriginalComponent, apiEndPoint) {
       } else {
         updatedFacets = selectedFacets.filter((facet) => (facet[1] !== facetValue));
       }
+      searchParams.page = 1;
       searchParams.facets = updatedFacets;
       await this.setState({
         searchParams,
@@ -304,7 +306,9 @@ export default function withSearch(OriginalComponent, apiEndPoint) {
     filteredFacets(facetKey) {
       const { totalFacets, selectedFacets, facetsResults } = this.state;
       const returnedFacets = totalFacets[facetKey].filter((facet) => {
-        const hasResults = facetsResults[facetKey].find((activeFacet) => (activeFacet[0] === facet[0]));
+        const hasResults = facetsResults[facetKey].find((activeFacet) => (
+          activeFacet[0] === facet[0]
+        ));
         const selected = selectedFacets.find((selectedFacet) => (
           (selectedFacet[0] === facet[0]) && (selectedFacet[0] === facetKey)
         ));


### PR DESCRIPTION
This PR updates the withSearch HOC to address a couple of issues:
1. It now takes props of selectedFacets to allow prefiltered results on pages.
1. Fixed a conditional check that was failing when comparing selectedFacets in the filterFacetList function. 
1. When changing pageSize or choosing a facet, the page will reset to 1 so you don't end up on page 5 but only a couple of results leading to an empty page.