### PR TITLE
Update ToggleBlock with open/close class and defaultClosed prop

### DIFF
--- a/src/components/ToggleBlock/index.jsx
+++ b/src/components/ToggleBlock/index.jsx
@@ -8,22 +8,23 @@ export default function ToggleBlock({
   headingClasses,
   innerClasses,
   allowToggle,
+  defaultClosed,
 }) {
-  const [showFacets, toggleShowFacets] = useState(true);
-  let facetBlockHeading = <h2 className={headingClasses}>{title}</h2>;
+  const [show, toggleShow] = useState(!defaultClosed);
+  let toggleBlockHeading = <h2 className={headingClasses}>{title}</h2>;
   if (allowToggle) {
-    facetBlockHeading = (
+    toggleBlockHeading = (
       <h2 className={headingClasses}>
-        <button type="button" onClick={() => toggleShowFacets(!showFacets)}>
+        <button type="button" onClick={() => toggleShow(!show)}>
           {title}
         </button>
       </h2>
     );
   }
   return (
-    <div className={className}>
-      {facetBlockHeading}
-      {showFacets
+    <div className={`${className} ${show ? 'open' : 'closed'}`}>
+      {toggleBlockHeading}
+      {show
         && (
           <div className={innerClasses}>
             {children}
@@ -35,16 +36,18 @@ export default function ToggleBlock({
 
 ToggleBlock.defaultProps = {
   allowToggle: true,
-  headingClasses: 'facet-block-title',
-  innerClasses: 'facet-block-inner',
-  className: '',
+  headingClasses: 'toggle-block-title',
+  innerClasses: 'toggle-block-inner',
+  className: 'toggle-block',
+  defaultClosed: false,
 };
 
 ToggleBlock.propTypes = {
-  title: PropTypes.string.isRequired,
+  title: PropTypes.node.isRequired,
   children: PropTypes.node.isRequired,
   headingClasses: PropTypes.string,
   innerClasses: PropTypes.string,
   allowToggle: PropTypes.bool,
   className: PropTypes.string,
+  defaultClosed: PropTypes.bool,
 };

--- a/src/components/ToggleBlock/index.test.jsx
+++ b/src/components/ToggleBlock/index.test.jsx
@@ -11,6 +11,15 @@ describe('<ToggleBlock />', () => {
     </ToggleBlock>,
   );
 
+  const defaultClosedWrapper = shallow(
+    <ToggleBlock
+      title="My Title"
+      defaultClosed
+    >
+      <p>Child Element</p>
+    </ToggleBlock>,
+  );
+
   const customWrapper = shallow(
     <ToggleBlock
       title="My Custom Title"
@@ -27,8 +36,8 @@ describe('<ToggleBlock />', () => {
   });
 
   it('renders with default classes', () => {
-    expect(defaultWrapper.exists('h2.facet-block-title')).toBe(true);
-    expect(defaultWrapper.exists('div.facet-block-inner')).toBe(true);
+    expect(defaultWrapper.exists('h2.toggle-block-title')).toBe(true);
+    expect(defaultWrapper.exists('div.toggle-block-inner')).toBe(true);
   });
 
   it('renders without button title', () => {
@@ -38,18 +47,29 @@ describe('<ToggleBlock />', () => {
 
   it('renders with custom headingClasses', () => {
     expect(customWrapper.exists('h2.custom-heading-class')).toBe(true);
-    expect(customWrapper.find('h2.facet-block-title').exists()).toBe(false);
+    expect(customWrapper.find('h2.toggle-block-title').exists()).toBe(false);
   });
 
   it('renders with custom innerClasses', () => {
     expect(customWrapper.exists('div.custom-inner-class')).toBe(true);
-    expect(customWrapper.find('div.facet-block-inner').exists()).toBe(false);
+    expect(customWrapper.find('div.toggle-block-inner').exists()).toBe(false);
+  });
+
+  it('renders in the closed state', () => {
+    expect(defaultClosedWrapper.find('div.toggle-block-inner').exists()).toBe(false);
+    expect(defaultClosedWrapper.exists('div.closed')).toBe(true);
   });
 
   it('toggles render of children', () => {
+    expect(defaultWrapper.exists('div.open')).toBe(true);
+    expect(defaultWrapper.exists('div.closed')).toBe(false);
     defaultWrapper.find('h2 button').simulate('click');
-    expect(defaultWrapper.find('div.facet-block-inner').exists()).toBe(false);
+    expect(defaultWrapper.find('div.toggle-block-inner').exists()).toBe(false);
+    expect(defaultWrapper.exists('div.closed')).toBe(true);
+    expect(defaultWrapper.exists('div.open')).toBe(false);
     defaultWrapper.find('h2 button').simulate('click');
-    expect(defaultWrapper.exists('div.facet-block-inner'));
+    expect(defaultWrapper.exists('div.toggle-block-inner'));
+    expect(defaultWrapper.exists('div.open')).toBe(true);
+    expect(defaultWrapper.exists('div.closed')).toBe(false);
   });
 });


### PR DESCRIPTION
This PR updates a couple of features of the ToggleBlock for better styling and removes the term facets from all the classes. The prop type for title was changed to node so html elements could be passed in without warning for more complicated titles with icons. I also added a class that switches based on open/close for styling icons and the option to set it defaulted to closed when rendered. 