### PR TITLE
Update to Dataset Resources and ApiDocs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/data-catalog-components",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "React Components for Open Data Catalogs.",
   "main": "lib/index.js",
   "repository": {

--- a/src/components/Resource/index.jsx
+++ b/src/components/Resource/index.jsx
@@ -7,8 +7,10 @@ import withResource from './withResource';
 import DataTable from './DataTable';
 import DataTableHeader from './DataTableHeader';
 import ResourceInfoTable from './InfoTable';
+import useDatasetUrl from '../../services/hooks/useDatasetUrl';
 
 const Resource = ({
+  data,
   dataPreview,
   dataInfo,
   dataFunctions,
@@ -23,6 +25,9 @@ const Resource = ({
       toggleShow(false);
     }
   }, [dataPreview.values.length]);
+
+  const datasetURL = useDatasetUrl(data.data);
+
   const { hideTable } = infoTableOptions;
   const { hideHeader } = headerOptions;
   const values = 'values' in dataPreview ? dataPreview.values : [];
@@ -31,85 +36,107 @@ const Resource = ({
   const pageSize = 'pageSize' in dataPreview ? dataPreview.pageSize : 20;
   const pages = Math.ceil(parseInt(dataPreview.rowsTotal, 10) / pageSize);
   const statistics = 'datastore_statistics' in dataInfo ? dataInfo.datastore_statistics : { rows: parseInt(dataPreview.rowsTotal, 10), columns: columns.length };
-  const FullScreenModal = () => (
-    <>
-      <DataTableHeader
-        dataPreview={dataPreview}
-        options={headerOptions}
-        dataFunctions={dataFunctions}
-        id={datasetId}
-        fullScreenMode
-      />
-      <DataTable
-        index={1}
-        key={dataKey}
-        loading={show}
-        pageSize={pageSize}
-        pages={pages}
-        data={values}
-        filtered={dataPreview.filters}
-        columns={dataFunctions.activeColumns(dataPreview.columns)}
-        density={dataPreview.density}
-        sortedChange={dataFunctions.sortChange}
-        filterChange={dataFunctions.filterChange}
-        pageChange={dataFunctions.pageChange}
-      />
-    </>
-  );
+  const FullScreenModal = () => {
+    if (dataKey) {
+      return (
+        <>
+          <DataTableHeader
+            dataPreview={dataPreview}
+            options={headerOptions}
+            dataFunctions={dataFunctions}
+            id={datasetId}
+            fullScreenMode
+          />
+          <DataTable
+            index={1}
+            key={dataKey}
+            loading={show}
+            pageSize={pageSize}
+            pages={pages}
+            data={values}
+            filtered={dataPreview.filters}
+            columns={dataFunctions.activeColumns(dataPreview.columns)}
+            density={dataPreview.density}
+            sortedChange={dataFunctions.sortChange}
+            filterChange={dataFunctions.filterChange}
+            pageChange={dataFunctions.pageChange}
+          />
+        </>
+      );
+    }
+    return null;
+  };
   return (
     <div className="resource-container">
-      <Loader backgroundStyle={{ backgroundColor: '#f9fafb' }} foregroundStyle={{ backgroundColor: '#f9fafb' }} show={show} message={<LoadingSpin width="3px" primaryColor="#007BBC" />}>
-        {(dataInfo.data && showFileDownload)
-          && (
-          <FileDownload
-            format={dataInfo.data.format}
-            downloadURL={dataInfo.data.downloadURL}
-            title={dataInfo.data.title}
-            key={`${dataKey}-file-download`}
-          />
-          ) }
-        {hideHeader
-          ? (
-            <div className="row-results">
-              <strong>Rows:</strong>
-              {' '}
-              {dataPreview.rowsTotal}
-            </div>
-          )
-          : (
-            <DataTableHeader
-              dataPreview={dataPreview}
-              options={headerOptions}
-              dataFunctions={dataFunctions}
-              id={datasetId}
-              FullScreenComponent={FullScreenModal}
+
+      {dataKey
+        ? (
+          <Loader backgroundStyle={{ backgroundColor: '#f9fafb' }} foregroundStyle={{ backgroundColor: '#f9fafb' }} show={show} message={<LoadingSpin width="3px" primaryColor="#007BBC" />}>
+            {(dataInfo.data && showFileDownload)
+              && (
+              <FileDownload
+                format={dataInfo.data.format}
+                downloadURL={datasetURL}
+                title={dataInfo.data.title}
+                key={`${dataKey}-file-download`}
+              />
+              ) }
+            {hideHeader
+              ? (
+                <div className="row-results">
+                  <strong>Rows:</strong>
+                  {' '}
+                  {dataPreview.rowsTotal}
+                </div>
+              )
+              : (
+                <DataTableHeader
+                  dataPreview={dataPreview}
+                  options={headerOptions}
+                  dataFunctions={dataFunctions}
+                  id={datasetId}
+                  FullScreenComponent={FullScreenModal}
+                />
+              )}
+            <DataTable
+              index={1}
+              key={dataKey}
+              loading={show}
+              pageSize={pageSize}
+              pages={pages}
+              data={values}
+              filtered={dataPreview.filters}
+              columns={dataFunctions.activeColumns(dataPreview.columns)}
+              density={dataPreview.density}
+              sortedChange={dataFunctions.sortChange}
+              filterChange={dataFunctions.filterChange}
+              pageChange={dataFunctions.pageChange}
             />
-          )}
-        <DataTable
-          index={1}
-          key={dataKey}
-          loading={show}
-          pageSize={pageSize}
-          pages={pages}
-          data={values}
-          filtered={dataPreview.filters}
-          columns={dataFunctions.activeColumns(dataPreview.columns)}
-          density={dataPreview.density}
-          sortedChange={dataFunctions.sortChange}
-          filterChange={dataFunctions.filterChange}
-          pageChange={dataFunctions.pageChange}
-        />
-        {!hideTable
-          && (
-            <ResourceInfoTable
-              statistics={statistics}
-              title={infoTableOptions.title}
-              th1={infoTableOptions.th1}
-              th2={infoTableOptions.th2}
-              tableclass={infoTableOptions.tableclass}
-            />
-          )}
-      </Loader>
+            {!hideTable
+              && (
+                <ResourceInfoTable
+                  statistics={statistics}
+                  title={infoTableOptions.title}
+                  th1={infoTableOptions.th1}
+                  th2={infoTableOptions.th2}
+                  tableclass={infoTableOptions.tableclass}
+                />
+              )}
+          </Loader>
+        )
+        : (
+          <div>
+            {data.data
+              && (
+                <FileDownload
+                  format={data.data.format}
+                  downloadURL={datasetURL}
+                  title={data.data.title}
+                  key={`${data.indentifier}-file-download`}
+                />
+              )}
+          </div>
+        )}
     </div>
   );
 };
@@ -135,6 +162,10 @@ Resource.defaultProps = {
 };
 
 Resource.propTypes = {
+  data: PropTypes.shape({
+    data: PropTypes.objectOf(PropTypes.string),
+    indentifier: PropTypes.string,
+  }).isRequired,
   headerOptions: PropTypes.shape({
     hideHeader: PropTypes.bool,
     options: PropTypes.objectOf(PropTypes.object),

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export { default as AdvancedOptions } from './components/Resource/DataTableHeader/AdvancedOptions';
+export { default as ApiDocs } from './components/ApiDocs';
 export { default as Blocks } from './components/Blocks';
 export { default as BasicBlock } from './components/Blocks/BasicBlock';
 export { default as Copyright } from './components/Copyright';

--- a/src/services/hooks/useDatasetUrl.js
+++ b/src/services/hooks/useDatasetUrl.js
@@ -1,0 +1,13 @@
+export default function useDatasetUrl(dist) {
+  const data = dist;
+
+
+  if (Object.prototype.hasOwnProperty.call(data, 'downloadURL')) {
+    return data.downloadURL;
+  }
+  if (Object.prototype.hasOwnProperty.call(data, 'accessURL')) {
+    return data.accessURL;
+  }
+
+  return null;
+}


### PR DESCRIPTION
Adds new check using data prop before withResource to load FileDownload components if no table is present. 

Adds a new custom hook that will allow for passing a dataset and getting the correct access/download url from the dataset distribution.

Adds the ApiDocs component to index.js for export and updates with new api paths. 