### PR TITLE
Moved search to hooks

### DIFF
--- a/src/components/Hero/index.jsx
+++ b/src/components/Hero/index.jsx
@@ -1,41 +1,56 @@
-/* eslint-disable */
-
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { navigate } from 'gatsby';
 import Wrapper from './Wrapper';
-import defaultTheme from '../../theme/default'
-import SearchInput from '../SearchInput'
+import defaultTheme from '../../theme/default';
+import SearchInput from '../SearchInput';
 
-class Hero extends React.Component {
-
-  render() {
-    const Background = this.props.image 
-      ? `url(${this.props.image})` 
-      : `linear-gradient(${defaultTheme.primaryDark}, ${defaultTheme.primary})`;
-    const Align = this.props.alignment;
-
-    return (
-      <Wrapper className="hero" style={{ backgroundImage: Background }}>
-        <div className={'block ' + Align}>
-          <h1 className="hero-title">{this.props.title}{this.props.title2}</h1>
-          <p>{this.props.intro}</p>
-          <SearchInput/>
-        </div>
-      </Wrapper>
-    );
+const Hero = ({
+  alignment,
+  title,
+  intro,
+  image,
+}) => {
+  const [query, setQuery] = useState('');
+  const background = image
+    ? `url(${image})`
+    : `linear-gradient(${defaultTheme.primaryDark}, ${defaultTheme.primary})`;
+  function handleSubmit(event) {
+    event.preventDefault();
+    navigate(`/search?q=${query}`);
   }
-}
+
+  return (
+    <Wrapper className="hero" style={{ backgroundImage: background }}>
+      <div className={`block ${alignment}`}>
+        <h1 className="hero-title">{title}</h1>
+        <p>{intro}</p>
+        <form onSubmit={(event) => handleSubmit(event)}>
+          <SearchInput
+            onChangeFunction={(event) => setQuery(event.target.value)}
+            onResetFunction={() => setQuery('')}
+            showSubmit
+            value={query}
+            resetContent="Clear"
+          />
+        </form>
+      </div>
+    </Wrapper>
+  );
+};
 
 Hero.defaultProps = {
-    state: "loading",
-    title: "Welcome to DKAN",
-    intro: "DKAN is an open-source data management platform. It treats data as content so that you can easily publish, manage, and maintain your open data no matter the size of your team or the level of technical expertise.",
-    alignment: "center",
+  alignment: 'center',
+  title: 'Welcome to DKAN',
+  intro: 'DKAN is an open-source data management platform. It treats data as content so that you can easily publish, manage, and maintain your open data no matter the size of your team or the level of technical expertise.',
+  image: '',
 };
 
 Hero.propTypes = {
-    state: PropTypes.string,
-    item: PropTypes.any,
+  title: PropTypes.string,
+  intro: PropTypes.string,
+  alignment: PropTypes.string,
+  image: PropTypes.string,
 };
 
 export default Hero;

--- a/src/components/SearchFacetBlocks/index.jsx
+++ b/src/components/SearchFacetBlocks/index.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FacetList from '../SearchFacetList';
+import { useFacetTypes } from '../../services/hooks/searchHooks';
+
+const SearchFacetBlocks = ({
+  className,
+  facets,
+  limit,
+  facetChangeFunc,
+}) => {
+  const facetTypes = useFacetTypes(facets.defaultFacets);
+  return (
+    <div className={className}>
+      {facetTypes.map((facetKey) => (
+        <FacetList
+          key={facetKey}
+          facetKey={facetKey}
+          selectedFacets={facets.selectedFacets}
+          facetResults={facets.facetResults}
+          limit={limit}
+          facetChangeFunc={facetChangeFunc}
+        />
+      ))}
+    </div>
+  );
+};
+
+SearchFacetBlocks.defaultProps = {
+  className: 'search-facet-blocks',
+  limit: 10,
+};
+
+SearchFacetBlocks.propTypes = {
+  className: PropTypes.string,
+  facets: PropTypes.objectOf(PropTypes.any).isRequired,
+  limit: PropTypes.number,
+  facetChangeFunc: PropTypes.func.isRequired,
+};
+
+export default SearchFacetBlocks;

--- a/src/components/SearchFacetList/index.jsx
+++ b/src/components/SearchFacetList/index.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ToggleBlock from '../ToggleBlock';
+import ShowMoreContainer from '../ShowMoreContainer';
+import { useFilteredFacets } from '../../services/hooks/searchHooks';
+
+const SearchFacetList = ({
+  facetKey,
+  selectedFacets,
+  facetResults,
+  limit,
+  facetChangeFunc,
+}) => {
+  const filteredFacets = useFilteredFacets(facetKey, selectedFacets, facetResults);
+
+  const choices = filteredFacets.map((result) => {
+    const type = 'checkbox';
+    const label = result[0];
+    const selected = selectedFacets.filter((selFacet) => selFacet[1] === result[0]).length > 0;
+    const key = `${facetKey}-${label.replace(/\s/g, '')}-${Math.random() * 10}`;
+    return (
+      <li key={key}>
+        <input
+          type={type}
+          name={facetKey}
+          value={label}
+          checked={selected}
+          onChange={facetChangeFunc}
+        />
+        {label}
+      </li>
+    );
+  });
+  return (
+    <ToggleBlock
+      key={facetKey}
+      title={facetKey}
+    >
+      <ShowMoreContainer
+        container="ol"
+        items={choices}
+        limit={limit}
+      />
+    </ToggleBlock>
+  );
+};
+
+SearchFacetList.defaultProps = {
+  limit: 10,
+};
+
+SearchFacetList.propTypes = {
+  facetKey: PropTypes.string.isRequired,
+  selectedFacets: PropTypes.arrayOf(PropTypes.array).isRequired,
+  facetResults: PropTypes.objectOf(PropTypes.array).isRequired,
+  limit: PropTypes.number,
+  facetChangeFunc: PropTypes.func.isRequired,
+};
+
+export default SearchFacetList;

--- a/src/components/SearchListItem/Wrapper.js
+++ b/src/components/SearchListItem/Wrapper.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 import styled from 'styled-components';
 
-const Wrapper = styled.div`
+const Wrapper = styled.li`
   background: #fff;
   border: 1px solid ${props => props.theme.borderColor};
   border-radius: 4px;

--- a/src/components/SearchListItem/index.jsx
+++ b/src/components/SearchListItem/index.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable */
 import React from 'react';
 import PropTypes from 'prop-types';
-import ListItem from '../ListItem';
 import Wrapper from './Wrapper';
 import excerpts from 'excerpts';
 import TopicImage from '../IconListItem/TopicImage';
@@ -9,105 +8,103 @@ import DataIcon from '../DataIcon';
 import Text from '../Text';
 import { Link } from "gatsby";
 
-class SearchListItem extends React.PureComponent { // eslint-disable-line react/prefer-stateless-function
-  formats(distribution) {
+const SearchListItem = ({
+  className,
+  item,
+}) => {
+  const { ref, title, description, publisher, format, theme, identifier } = item;
+
+  function formats(distribution) {
     if (!distribution) {
       return null;
     }
-    else {
-      let i = 0;
+    if(typeof distribution === 'object') {
+      distribution = Object.entries(distribution);
       return distribution.map((dist) => {
-        i++
-        const format = dist.format === undefined ? '' : dist.format.toLowerCase();
-        return <div title={`format: ${dist.format}`}
-          key={`dist-id-${dist.identifier}-${i}`}
-          className="label"
-          data-format={format}>{format}</div>
+        const format = (dist[1] === undefined) ? '' : dist[1].format.toLowerCase();
+        return (
+          <div title={`format: ${dist.format}`}
+            key={`dist-id-${identifier}-${Math.random() * 10}`}
+            className="label"
+            data-format={format}>{format}
+          </div>
+        );
       })
+    }
+
+    if(Array.isArray(distribution)) {
+      return distribution.map((dist) => {
+        const format = (dist.format === undefined) ? '' : dist.format.toLowerCase();
+        return (
+          <div title={`format: ${dist.format}`}
+            key={`dist-id-${identifier}-${Math.random() * 10}`}
+            className="label"
+            data-format={format}>{format}
+          </div>
+        );
+      });
     }
   }
 
-  themes(theme) {
+  function themes(theme) {
     if (!theme) {
       return null;
-    }
-    else {
-      let i = 0;
-      return theme.map(function(topic) {
-        i++
-        // if (topic.icon) {
-        //   return <div key={`dist-${topic.identifier}-${i}`}>
-        //     <img src={topic.icon} height="16px" width="16px" alt={topic.alt} /> 
-        //     {topic.title}
-        //   </div>
-        // }
-        // else {
-          return <Link key={`dist-${topic.identifier}-${i}`} to={`search?theme=${topic.title}`}>
+    } else {
+      return theme.map((topic) => {
+        return(
+          <Link
+            key={`dist-${topic.identifier}-${Math.random() * 10}`}
+            to={"search?topics=" + topic.title}
+          >
             <TopicImage title={topic.title} height="16" width="16"/>
             {topic.title}
           </Link>
-          
-        //}
-        
+        );
       })
     }
   }
 
-  render() {
+  return(
+    <Wrapper className={className}>
+      <h2><Link to={ref}>{title}</Link></h2>
+      
+      {(publisher && publisher.name !== undefined) &&
+        <div className="item-publisher">
+          <DataIcon icon="group" height="20" width="20" color="#A7AAAC"/>
+          <Text tag="i" value={publisher.name} />
+        </div>
 
-    const item = this.props.item;
-    const description = item.description ? 
-      <Text className="item-description">
-        {excerpts(item.description, {words: 35})}
-      </Text> 
-      : '';
-    const publisher = item.publisher ? 
-      <div className="item-publisher">
-        <DataIcon icon="group" height="20" width="20" color="#A7AAAC"/>
-        <Text tag="i" value={item.publisher.name} />
-      </div>
-      : '';
-    const formats = item.format ?
-      <div className="format-types">
-        {this.formats(item.format)}
-      </div>
-      : '';
-    const themes = item.theme ?
-      <div className="item-theme">
-        {this.themes(item.theme)}
-      </div>
-      : '';
-    // Put together the content of the repository
-    const content = (
-      <Wrapper key={`wrapper-${item.identifier}`} className="search-list-item">
-        <a href={item.ref}>
-          <h2>{ item.title }</h2>
-        </a>
-        {publisher}
-        {themes}
-        {description}
-        {formats}
-      </Wrapper>
-    );
+      }
 
-    return (
-      <ListItem key={`repo-list-item-${item.identifier}`} item={content} />
-    );
-  }
+      {theme &&
+        <div className="item-theme">
+          {themes(theme)}
+        </div>
+      }
+
+      {description &&
+        <Text className="item-description">
+          {excerpts(description, {words: 35})}
+        </Text>
+      }
+
+      {format &&
+        <div className="format-types">
+          {formats(format)}
+        </div>
+      }
+
+    </Wrapper>
+  );
 }
 
 SearchListItem.defaultProps = {
-  item: {
-    "identifier": 1234,
-    "title": "This is a title",
-    "description": "I am an item",
-    "modified": "1/12/2018",
-    "publisher": "Publish Inc."
-  },
+  className: 'search-list-item',
 };
 
 SearchListItem.propTypes = {
-  item: PropTypes.object,
+  className: PropTypes.string,
+  item: PropTypes.objectOf(PropTypes.any).isRequired,
 };
 
 export default SearchListItem;

--- a/src/components/SearchPageSizer/index.jsx
+++ b/src/components/SearchPageSizer/index.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SearchPageSizer = ({
+  className,
+  currentValue,
+  inputClasses,
+  label,
+  options,
+  resizeFunc,
+  showLabel,
+}) => (
+  <div className={className}>
+    {showLabel
+      && <label htmlFor="search-page-sizer">{label}</label> }
+    <select
+      id="search-page-sizer"
+      className={inputClasses}
+      value={currentValue}
+      onChange={resizeFunc}
+    >
+      {options.map((opt) => <option key={opt} value={opt}>{opt}</option>)}
+    </select>
+  </div>
+);
+
+SearchPageSizer.defaultProps = {
+  className: 'search-page-sizer',
+  inputClasses: 'search-page-sizer-input',
+  label: 'Page Size',
+  options: [5, 10, 25, 50],
+  showLabel: true,
+};
+
+SearchPageSizer.propTypes = {
+  className: PropTypes.string,
+  currentValue: PropTypes.number.isRequired,
+  inputClasses: PropTypes.string,
+  label: PropTypes.string,
+  options: PropTypes.arrayOf(PropTypes.number),
+  resizeFunc: PropTypes.func.isRequired,
+  showLabel: PropTypes.bool,
+};
+
+export default SearchPageSizer;

--- a/src/components/SearchPaginationResults/index.jsx
+++ b/src/components/SearchPaginationResults/index.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SearchPaginationResults = ({
+  className,
+  currentPage,
+  pageSize,
+  total,
+}) => {
+  const startingNumber = total > 0 ? 1 : 0;
+  const currentLowestResult = startingNumber + ((pageSize * currentPage) - pageSize);
+  let currentHighestResult = (pageSize * currentPage);
+  if (currentHighestResult > total) {
+    currentHighestResult = total;
+  }
+  return (
+    <div className={className}>
+      {currentLowestResult}
+      -
+      {currentHighestResult}
+      {' '}
+      out of
+      {' '}
+      {total}
+      {' '}
+      datasets
+    </div>
+  );
+};
+
+SearchPaginationResults.defaultProps = {
+  className: 'dataset-results-count',
+};
+
+SearchPaginationResults.propTypes = {
+  className: PropTypes.string,
+  currentPage: PropTypes.number.isRequired,
+  pageSize: PropTypes.number.isRequired,
+  total: PropTypes.number.isRequired,
+};
+
+export default SearchPaginationResults;

--- a/src/components/SearchSort/index.jsx
+++ b/src/components/SearchSort/index.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SearchSort = ({
+  className,
+  currentValue,
+  inputClasses,
+  label,
+  options,
+  sortFunc,
+}) => (
+  <div className={className}>
+    <label htmlFor="search-sort">{label}</label>
+    <select
+      id="search-sort"
+      className={inputClasses}
+      value={currentValue}
+      onChange={sortFunc}
+    >
+      {options.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+    </select>
+  </div>
+);
+
+
+SearchSort.defaultProps = {
+  className: 'search-sort',
+  inputClasses: 'search-sort-input',
+  label: 'Sort by',
+  options: [
+    { value: 'relevance', label: 'Relevance' },
+    { value: 'date', label: 'Date' },
+    { value: 'alpha', label: 'Alphabetical' },
+  ],
+};
+
+SearchSort.propTypes = {
+  className: PropTypes.string,
+  currentValue: PropTypes.string.isRequired,
+  inputClasses: PropTypes.string,
+  label: PropTypes.string,
+  options: PropTypes.arrayOf(PropTypes.shape({
+    value: PropTypes.string,
+    label: PropTypes.string,
+  })),
+  sortFunc: PropTypes.func.isRequired,
+};
+
+export default SearchSort;

--- a/src/index.js
+++ b/src/index.js
@@ -22,10 +22,15 @@ export { default as NavBar } from './components/NavBar';
 export { default as Organization } from './components/Organization';
 export { default as PageHeader } from './components/PageHeader';
 export { default as Resource } from './components/Resource';
+export { default as SearchFacetBlocks } from './components/SearchFacetBlocks';
+export { default as SearchFacetList } from './components/SearchFacetList';
 export { default as SearchInput } from './components/SearchInput';
 export { default as SearchList } from './components/SearchList';
 export { default as SearchListItem } from './components/SearchListItem';
+export { default as SearchPageSizer } from './components/SearchPageSizer';
+export { default as SearchPaginationResults } from './components/SearchPaginationResults';
 export { default as SearchResultsMessage } from './components/SearchResultsMessage';
+export { default as SearchSort } from './components/SearchSort';
 export { default as ShowMoreContainer } from './components/ShowMoreContainer';
 export { default as StatBlock } from './components/Blocks/StatBlock';
 export { default as StepsBlock } from './components/Blocks/StepsBlock';
@@ -38,3 +43,11 @@ export { default as Title } from './components/Title';
 export { default as ToggleBlock } from './components/ToggleBlock';
 export { default as withSearch } from './components/Search/withSearch';
 export { default as withResource } from './components/Resource/withResource';
+
+export {
+  useSearchData,
+  useLunrSearch,
+  useFacetTypes,
+  useUrlParams,
+  useFilteredFacets,
+} from './services/hooks/searchHooks';

--- a/src/services/context/ResourceContext.js
+++ b/src/services/context/ResourceContext.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const ResourceContext = React.createContext();
+
+export default ResourceContext;

--- a/src/services/datastore.js
+++ b/src/services/datastore.js
@@ -51,7 +51,6 @@ export class file extends Datastore {
     return new Promise( (resolve, reject) => {
       this._fetch().then(
         (data) => {
-          console.log(data)
           data = this._query(data, query)
 
           if (count) {

--- a/src/services/hooks/searchHooks.js
+++ b/src/services/hooks/searchHooks.js
@@ -1,0 +1,159 @@
+import React from 'react';
+import axios from 'axios';
+import queryString from 'query-string';
+import search from '../search';
+
+export function useLunrSearch(url, defaultFacets) {
+  const [searchEngine, setSearchEngine] = React.useState();
+  React.useEffect(() => {
+    // eslint-disable-next-line dot-notation
+    const newSearchEngine = new search['Lunr']();
+    async function fetchSearchIndex() {
+      const data = await axios.get(url);
+      return data;
+    }
+    async function initSearchEngine() {
+      const { data } = await fetchSearchIndex();
+      await newSearchEngine.init(data, defaultFacets);
+      await setSearchEngine(newSearchEngine);
+    }
+    initSearchEngine();
+  }, [url, defaultFacets]);
+
+  return searchEngine;
+}
+
+export function useSearchData(
+  searchEngine,
+  searchPage,
+  searchQuery,
+  searchSort,
+  searchPageSize,
+  selectedFacets,
+) {
+  const [loading, setLoading] = React.useState(true);
+  const [totalResults, setTotalResults] = React.useState(0);
+  const [facetResults, setFacetResults] = React.useState({});
+  const [items, setItems] = React.useState([]);
+
+  React.useEffect(() => {
+    function normalizeItems(resultItems) {
+      return resultItems.map((x) => {
+        let item = {};
+        item = {
+          identifier: x.identifier,
+          modified: x.modified,
+          description: x.description,
+          theme: x.theme,
+          format: x.distribution,
+          title: x.title,
+          ref: `/dataset/${x.identifier}`,
+        };
+        if (Object.prototype.hasOwnProperty.call(x, 'publisher') && Object.prototype.hasOwnProperty.call(x, 'name')) {
+          item.publisher = x.publisher.name;
+        } else {
+          item.publisher = '';
+        }
+        return item;
+      });
+    }
+
+    async function fetchData() {
+      if (searchEngine !== null) {
+        const results = await searchEngine.query(
+          searchQuery, selectedFacets, searchPageSize, searchPage, searchSort,
+        );
+        setFacetResults(results.facetsResults);
+        setItems(normalizeItems(results.results));
+        setTotalResults(results.total);
+        setLoading(false);
+      }
+    }
+
+    if (searchEngine !== undefined) {
+      fetchData();
+    }
+  }, [
+    searchEngine, searchPage, searchQuery, searchSort, searchPageSize, selectedFacets,
+  ]);
+
+  return [loading, items, facetResults, totalResults];
+}
+
+
+export function useFacetTypes(facets) {
+  const facetTypes = Object.keys(facets);
+  return facetTypes;
+}
+
+export function useUrlParams(
+  searchUrl, defaultFacets, searchPage, searchQuery, searchSort, searchPageSize, selectedFacets,
+) {
+  const [newParams, setNewParams] = React.useState({});
+  const facetKeys = Object.keys(defaultFacets);
+
+  React.useEffect(() => {
+    const params = {};
+    params.sort = searchSort;
+    params.page = searchPage;
+    params.pageSize = searchPageSize;
+    params.q = searchQuery;
+
+    facetKeys.map((key) => {
+      let paramString = '';
+      const facetItems = selectedFacets.filter((param) => {
+        if (param[0] === key) {
+          return param[1];
+        }
+        return false;
+      });
+
+      facetItems.map((item) => {
+        paramString += `${item[1]},`;
+        return paramString;
+      });
+
+      paramString = paramString.slice(0, -1);
+      if (paramString) {
+        params[key] = paramString;
+      }
+      return paramString;
+    });
+    setNewParams(params);
+  }, [searchSort, searchPage, searchPageSize, searchQuery, selectedFacets]);
+
+  return `${searchUrl}?${queryString.stringify(newParams)}`;
+}
+
+export function useFilteredFacets(facetKey, selectedFacets, facetResults) {
+  const [returnedFacets, setReturnedFacets] = React.useState([]);
+
+  React.useEffect(() => {
+    const filteredFacets = facetResults[facetKey].filter((facet) => {
+      const hasResults = facetResults[facetKey].find((activeFacet) => (
+        activeFacet[0] === facet[0]
+      ));
+      const selected = selectedFacets.find((selFacet) => (
+        (selFacet[1].toLowerCase() === facet[0].toLowerCase())
+          && (selFacet[0].toLowerCase() === facetKey.toLowerCase())
+      ));
+
+      if (selected || hasResults) {
+        return facet;
+      }
+      return false;
+    }).map((facet) => {
+      const hasResults = facetResults[facetKey].find((activeFacet) => (
+        activeFacet[0] === facet[0]
+      ));
+
+      if (hasResults) {
+        return [facet[0], hasResults[1]];
+      }
+      return [facet[0], 0];
+    });
+
+    setReturnedFacets(filteredFacets);
+  }, [facetKey, selectedFacets, facetResults]);
+  return returnedFacets;
+}

--- a/src/services/search.js
+++ b/src/services/search.js
@@ -103,7 +103,7 @@ class Search {
         }
       }
 
-      if (doc[current] !== undefined) {
+      if (doc[current] !== undefined && doc[current] !== null) {
         // This is the property no need to recurse further.
         if (pieces.length === 0) {
           if (doc == null) {


### PR DESCRIPTION
This PR isn't complete in terms of testing and storybook. I didn't have time to add all of those in, but it does seem to work with https://github.com/GetDKAN/data-catalog-frontend/pull/6 

I've left withSearch in for any sites using it currently, but this is a complete overhaul of the search section of the site. I was able to distill the withSearch down to just a couple of hooks that utilize the side effect paradigm. Most of the state is initially set in the search component on the demo site, similar to the default searchparam object from before, but now all that is stored in `useState`. The new hooks in this repo now just watch for those state variables to change and if they do it rerenders the search page updating the results and url. 

There is still some work that has to be done on the search.js to fix some issues of facets that share words, but it should mostly work. 

One breaking issue from the master branch I found was in SearchListItem. It required an array of distributions which was not always the case in some datasets. There were some in my new test batches that included the distributions in objects, not arrays. This would break the site when it attempted to map these. I added an additional check to SearchListItem that will check for array or object and then if array continue as normal. If object it will turn it into an array and map the first item. I am not sure if this is supposed to have been changed during harvests, so I just added enough code to fix it. 