### PR TITLE
Adds title attribute to Display Density buttons along with Storybook story

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "@storybook/addon-a11y": "^5.2.0",
-    "@storybook/addon-actions": "^5.2.0",
+    "@storybook/addon-actions": "^5.3.8",
     "@storybook/addon-knobs": "^5.2.0",
     "@storybook/addon-links": "^5.2.0",
     "@storybook/addons": "^5.2.0",

--- a/src/components/Resource/DataTableHeader/DataTableDensity/index.jsx
+++ b/src/components/Resource/DataTableHeader/DataTableDensity/index.jsx
@@ -17,7 +17,12 @@ const DataTableDensity = ({
           srClass = '';
         }
         return (
-          <button type="button" key={item.text} onClick={() => densityChange(item.value)}>
+          <button
+            type="button"
+            key={item.text}
+            onClick={() => densityChange(item.value)}
+            title={item.text}
+          >
             {item.icon
               && (
                 <>

--- a/stories/dataset.stories.jsx
+++ b/stories/dataset.stories.jsx
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react';
 import {
   withKnobs, text, select, number,
 } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 import { withA11y } from '@storybook/addon-a11y';
 import FormatIcon from '../src/components/FormatIcon';
 import FileDownload from '../src/components/FileDownload';
@@ -10,6 +11,7 @@ import Organization from '../src/components/Organization';
 import Text from '../src/components/Text';
 import Table from '../src/components/Table';
 import Tags from '../src/components/Tags';
+import DataTableDensity from '../src/components/Resource/DataTableHeader/DataTableDensity';
 import DataTablePageResults from '../src/components/Resource/DataTableHeader/DataTablePageResults';
 import data from './data/data.json';
 import tables from './data/tables.json';
@@ -58,5 +60,16 @@ storiesOf('Dataset', module)
       total={number('Total', 100)}
       pageSize={number('Page Size', 10)}
       currentPage={number('Current Page', 0)}
+    />
+  ))
+  .add('Datatable Density Buttons', () => (
+    <DataTableDensity
+      items={[
+        { icon: null, text: text('Density Button 1', 'Expanded'), value: 'density-1' },
+        { icon: null, text: text('Density Button 2', 'Normal'), value: 'density-2' },
+        { icon: null, text: text('Density Button 3', 'Tight'), value: 'density-3' },
+      ]}
+      title={text('Title', 'Display Density')}
+      densityChange={action('clicked')}
     />
   ));


### PR DESCRIPTION
While fixing a downstream button I realized we didn't have a title on each of the buttons for density. This update adds a title attribute that uses the text prop that is passed to each button. For testing, I also added a new story to the Storybook to show the work as it didn't change any functionality. 