### PR TITLE
Update @import for bootstrap and update version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/data-catalog-components",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "React Components for Open Data Catalogs.",
   "main": "lib/index.js",
   "repository": {

--- a/src/theme/styles/index.scss
+++ b/src/theme/styles/index.scss
@@ -1,8 +1,8 @@
 // Storybook
 // @import '../../../node_modules/bootstrap/dist/css/bootstrap.min.css';
 // Local Dev
-@import '../node_modules/bootstrap/dist/css/bootstrap.min.css';
 
+@import '~bootstrap/dist/css/bootstrap.min.css';
 @import "general.scss";
 
 // Component styles.


### PR DESCRIPTION
Found a possibly solution for bootstrap. It looks like you can use a `~` in the import line to grab it from node modules, I think.

https://stackoverflow.com/questions/49518277/import-css-from-node-modules-in-webpack