### PR TITLE
Adjust facet label to be full width

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,3 +68,4 @@ export { default as StatBlock } from './templates/Blocks/StatBlock';
 export { default as StepsBlock } from './templates/Blocks/StepsBlock';
 export { default as SearchSidebar } from './templates/SearchSidebar';
 export { default as SearchContent } from './templates/SearchContent';
+export { default as TopicIcon } from './templates/TopicIcon';

--- a/src/templates/SearchSidebar/searchsidebar.scss
+++ b/src/templates/SearchSidebar/searchsidebar.scss
@@ -44,7 +44,11 @@
     max-width: 100%;
     min-height: 32px;
     position: relative;
-
+    label {
+      display: block;
+      cursor: pointer;
+      width: 100%;
+    }
     input {
       left: -999em;
       opacity: 0;


### PR DESCRIPTION
- export the TopicIcon template
- updates the facet option css so that the full width of the option is clickable