### PR TITLE
Add DataIcon as export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/data-catalog-components",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "React Components for Open Data Catalogs.",
   "main": "lib/index.js",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 export { default as AdvancedOptions } from './components/Resource/DataTableHeader/AdvancedOptions';
 export { default as AdvancedOptionsForm } from './components/Resource/DataTableHeader/AdvancedOptions/AdvancedOptionsForm';
 export { default as ApiDocs } from './components/ApiDocs';
+export { default as DataIcon } from './components/DataIcon';
 export { default as DataTable } from './components/Resource/DataTable';
 export { default as DataTableHeader } from './components/Resource/DataTableHeader';
 export { default as DataTableDensity } from './components/Resource/DataTableHeader/DataTableDensity';


### PR DESCRIPTION
DataIcon exists in the library only for internal components. This just adds it to the export list to be used in frontend code.