### PR TITLE
move styling to be available in multiple places

### DIFF
--- a/src/components/SearchListItem/searchlistitem.scss
+++ b/src/components/SearchListItem/searchlistitem.scss
@@ -32,24 +32,6 @@
       }
     }
   }
-  .dc-item-theme {
-    font-style: normal;
-    letter-spacing: .25px;
-    margin: .5em 0;
-    padding-bottom: .75em;
-    a {
-      color: $primary;
-      display: inline-block;
-      position: relative;
-      padding: 0 20px 0 30px;
-    }
-    img, svg {
-      position: absolute;
-      top:0;
-      left:0;
-      fill: $primary;
-    }
-  }
   .format-types {
     display: flex;
     align-items: flex-start;

--- a/src/components/TopicWrapper/topicwrapper.scss
+++ b/src/components/TopicWrapper/topicwrapper.scss
@@ -14,3 +14,21 @@
     }
   }
 }
+.dc-item-theme {
+  font-style: normal;
+  letter-spacing: .25px;
+  margin: .5em 0;
+  padding-bottom: .75em;
+  a {
+    color: $primary;
+    display: inline-block;
+    position: relative;
+    padding: 0 20px 0 30px;
+  }
+  img, svg {
+    position: absolute;
+    top:0;
+    left:0;
+    fill: $primary;
+  }
+}


### PR DESCRIPTION
This will allow the TopicWrapper styles to work on the SearchListItem and on the dataset template for a consistent display of themes.

This pairs nicely with https://github.com/GetDKAN/data-catalog-frontend/pull/26