### PR TITLE
Lock swagger-ui-react to 3.25.0 to fix breaking api page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     parameters:
       pr-version:
         type: string
-        default: "0.1.11"
+        default: "0.1.12"
     parallelism: 1
     machine:
       image: circleci/classic:latest

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "react-test-renderer": "^16.9.0",
     "sass-loader": "^7.1.0",
     "styled-components": "^5.0.1",
-    "swagger-ui-react": "^3.23.9",
+    "swagger-ui-react": "3.25.0",
     "url-loader": "^1.1.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/data-catalog-components",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "React Components for Open Data Catalogs.",
   "main": "lib/index.js",
   "repository": {
@@ -31,6 +31,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "axios": "^0.19.0",
+    "bootstrap": "^4.2.1",
     "excerpts": "0.0.3",
     "html-to-react": "^1.3.4",
     "lodash": "^4.17.15",
@@ -46,10 +47,13 @@
     "react-dnd-test-backend": "^9.4.0",
     "react-dnd-test-utils": "^9.4.0",
     "react-dnd-touch-backend-cjs": "^9.4.0",
+    "react-js-pagination": "^3.0.2",
     "react-loader-advanced": "^1.7.1",
     "react-loading-spin": "^1.0.9",
     "react-table": "^6.10.3",
     "reactstrap": "^7.1.0",
+    "styled-components": "^5.0.1",
+    "swagger-ui-react": "3.25.0",
     "validator": "^12.2.0"
   },
   "devDependencies": {
@@ -93,7 +97,6 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.24.1",
-    "bootstrap": "^4.2.1",
     "core-js": "^2.6.5",
     "css-loader": "^2.1.0",
     "enzyme": "^3.10.0",
@@ -108,12 +111,9 @@
     "jest": "^24.9.0",
     "node-sass": "^4.13.1",
     "prettier": "^1.16.0",
-    "react-js-pagination": "^3.0.2",
     "react-router-dom": "^4.3.1",
     "react-test-renderer": "^16.9.0",
     "sass-loader": "^7.1.0",
-    "styled-components": "^5.0.1",
-    "swagger-ui-react": "3.25.0",
     "url-loader": "^1.1.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
Fix issue with newest version of swagger-ui-react breaking api pages.