### PR TITLE
Release patch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     parameters:
       pr-version:
         type: string
-        default: "1.0.0"
+        default: "1.0.1"
     parallelism: 1
     machine:
       image: circleci/classic:latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/data-catalog-components",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "React Components for Open Data Catalogs.",
   "main": "lib/index.js",
   "repository": {

--- a/src/components/DataTable/ManageColumns/index.jsx
+++ b/src/components/DataTable/ManageColumns/index.jsx
@@ -62,6 +62,7 @@ const ManageColumns = ({
       <Modal
         title="Manage Columns"
         nodeId="___gatsby"
+        openText="Manage Columns"
       >
         <DndProvider backend={Backend}>
           {reactTable.allColumns

--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -46,7 +46,7 @@ const Modal = ({
               type="button"
               id={`dc-modal-${titleId}-close`}
               onClick={() => setModalOpen(false)}
-              className="dc-modal-close-button btn btn-primary"
+              className="dc-modal-close-button btn"
             >
               {closeText}
             </button>
@@ -59,7 +59,7 @@ const Modal = ({
   return (
     <div className="dc-modal-container">
       <button
-        className="dc-modal-open-button btn btn-primary"
+        className="dc-modal-open-button btn"
         id={`dc-modal-${titleId}-open`}
         type="button"
         onClick={() => setModalOpen(!modalOpen)}

--- a/src/components/Resource/index.jsx
+++ b/src/components/Resource/index.jsx
@@ -76,7 +76,6 @@ const Resource = ({
   ]);
 
   const { columns, currentPage } = resourceState;
-  console.log(columns);
   const data = resourceState.values;
 
 

--- a/src/services/resource/resource_functions.js
+++ b/src/services/resource/resource_functions.js
@@ -69,7 +69,6 @@ export async function queryResourceData(resourceData, showDBCols = false, includ
   // const {
   //   filters, pageSize, currentPage, sort, store,
   // } = resourceData;
-  console.log('q', showDBCols)
   const items = await resourceData.store.query(
     resourceData.filters,
     null,

--- a/src/services/resource/resource_reducer.js
+++ b/src/services/resource/resource_reducer.js
@@ -32,14 +32,12 @@ export default function resourceReducer(state, action) {
         updateQuery: false,
       };
     case 'UPDATE_PAGE':
-      console.log('UPDATE_PAGE')
       return {
         ...state,
         currentPage: action.data.page,
         updateQuery: true,
       };
     case 'UPDATE_FILTERS':
-      console.log('UPDATE_FILTERS')
       return {
         ...state,
         filters: action.data.filters,
@@ -47,7 +45,6 @@ export default function resourceReducer(state, action) {
         updateQuery: true,
       };
     case 'UPDATE_PAGE_SIZE':
-      console.log('UPDATE_PAGE_SIZE')
       return {
         ...state,
         pageSize: Number(action.data.pageSize),
@@ -55,28 +52,24 @@ export default function resourceReducer(state, action) {
         updateQuery: true,
       };
     case 'UPDATE_COLUMN_SORT':
-      console.log('UPDATE_COLUMN_SORT')
       return {
         ...state,
         sort: action.data.sort,
         updateQuery: true,
       };
     case 'REORDER_COLUMNS':
-      console.log('REORDER_COLUMNS')
       return {
         ...state,
         columnOrder: action.data.columnOrder,
         updateQuery: true,
       };
     case 'TOGGLE_COLUMNS':
-      console.log('TOGGLE_COLUMNS')
       return {
         ...state,
         excludedColumns: action.data.excludedColumns,
         updateQuery: true,
       };
     case 'UPDATE_DENSITY':
-      console.log('UPDATE_DENSITY')
       return {
         ...state,
         density: action.data.density,

--- a/src/templates/DataTable/index.jsx
+++ b/src/templates/DataTable/index.jsx
@@ -44,6 +44,11 @@ const DataTable = () => {
       }
     }
   }, [resourceState.store, filters]);
+
+  if (!reactTable.data.length) {
+    return null;
+  }
+
   return (
     <div className={`dc-datatable -striped -highlight ${density}`}>
       <div {...getTableProps()} role="grid" className="dc-table">

--- a/src/templates/DataTableHeader/index.jsx
+++ b/src/templates/DataTableHeader/index.jsx
@@ -8,6 +8,10 @@ import DataIcon from '../../components/DataIcon';
 
 const DataTableHeader = () => {
   const { reactTable, resourceState, dispatch } = React.useContext(ResourceDispatch);
+
+  if (!reactTable.data.length) {
+    return null;
+  }
   return (
     <div className="dc-datatable-header">
       {resourceState.store


### PR DESCRIPTION
Fixes #63 
I've also included a fix for the pagination appearing before the tables build or if something happens and there is no data for the tables. This should address the issue seen in the Polling demo dataset.

The last commit removes some of the console.logs that I accidentally left in the 1.0.0 release.