### PR TITLE
Remove scarf dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/data-catalog-components",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "React Components for Open Data Catalogs.",
   "main": "lib/index.js",
   "repository": {
@@ -32,7 +32,6 @@
     "@fortawesome/free-solid-svg-icons": "^5.11.2",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "@reach/router": "^1.3.3",
-    "@scarf/scarf": "^1.0.4",
     "axios": "^0.19.0",
     "bootstrap": "^4.2.1",
     "excerpts": "0.0.3",
@@ -130,8 +129,5 @@
   "files": [
     "lib",
     "dist"
-  ],
-  "scarfSettings": {
-    "enabled": false
-  }
+  ]
 }


### PR DESCRIPTION
Addresses #83 removing scarf dependency that was added to fix an issue with build steps. We don't use it for anything so this shouldn't break any of our code. Bumped a minor version since we may have a major version change. 