### PR TITLE
Adjust sort_order to sort-order to make uniform with page-size

### DIFF
--- a/src/components/Search/functions.js
+++ b/src/components/Search/functions.js
@@ -17,7 +17,7 @@ function getApiSearchParams(searchState, defaultFacets, sortOptions) {
   state = Object.assign(state, searchState);
 
   const facetKeys = Object.keys(defaultFacets);
-  const urlOptions = ['fulltext', 'sort', 'sort_order', 'page-size', 'page', ...facetKeys];
+  const urlOptions = ['fulltext', 'sort', 'sort-order', 'page-size', 'page', ...facetKeys];
 
   // Figure out sort options
   const currentSort = getSortParams(state, sortOptions);

--- a/src/components/Search/index.jsx
+++ b/src/components/Search/index.jsx
@@ -45,7 +45,7 @@ const Search = ({
     actions.page = 'UPDATE_CURRENT_PAGE';
     actions.fulltext = 'UPDATE_FULLTEXT';
     actions.sort = 'UPDATE_SORT_ONLY';
-    actions.sort_order = 'UPDATE_SORT_ORDER';
+    actions['sort-order'] = 'UPDATE_SORT_ORDER';
 
     const urlOptions = Object.keys(actions);
 
@@ -129,7 +129,7 @@ const Search = ({
     const state = { ...searchState };
 
     // Set other url parameters
-    const urlOptions = ['fulltext', 'sort', 'sort_order', 'page-size', 'page'];
+    const urlOptions = ['fulltext', 'sort', 'sort-order', 'page-size', 'page'];
     urlOptions.forEach((option) => {
       // We only want to store state in the url if they are not the default state.
       if (state[option] && state[option] !== defaultState[option]) {

--- a/src/services/search/doc.mdx
+++ b/src/services/search/doc.mdx
@@ -12,7 +12,7 @@ Below is the list of possible reducers available in the Search component.
 1. **GET_SEARCH_ENGINE:** Sets **loading** to `false`, **searchEngine** to the value passed through `action.data.searchEngine`, **searchType** to the value passed through `action.data.searchType`, and **facets** to the value passed through `action.data.facets`.
 1. **GET_SEARCH_DATA:** Sets **loading** to `false`, **totalItems** to the value passed through `action.data.totalItems`, **items** to the value passed through `action.data.items`, and **facetsResults** to the value passed through `action.data.facetsResults`.
 1. **SET_SEARCH_PARAMETERS:** Sets **searchURL** to the value passed through `action.data.searchURL`.
-1. **UPDATE_SORT:** Sets **sort** to the value passed through `action.data.sort` and sets **sort_order** to the value passed through `action.data.sort_order`.
+1. **UPDATE_SORT:** Sets **sort** to the value passed through `action.data.sort` and sets **sort-order** to the value passed through `action.data['sort-order']`.
 1. **UPDATE_FULLTEXT:** Sets **fulltext** to the value passed through `action.data.fulltext`.
 1. **UPDATE_PAGE_SIZE:** Sets **page-size** to the value passed through `action.data['page-size']` and resets **page** to `1`.
 1. **UPDATE_CURRENT_PAGE:** Sets **page** to the value passed through `action.data.page`.

--- a/src/services/search/search_defaults.js
+++ b/src/services/search/search_defaults.js
@@ -11,6 +11,6 @@ export const defaultSearchState = {
   fulltext: '',
   selectedFacets: [],
   sort: 'modified',
-  sort_order: 'desc',
+  'sort-order': 'desc',
   totalItems: 0,
 };

--- a/src/services/search/search_functions.js
+++ b/src/services/search/search_functions.js
@@ -42,5 +42,5 @@ export function buildInitialFacets(queryParams, defaultFacets) {
 
 export function updateSort(value, options) {
   const newSort = options.filter((opt) => opt.field === value);
-  return { type: 'UPDATE_SORT', data: { sort: newSort[0].field, sort_order: newSort[0].order } };
+  return { type: 'UPDATE_SORT', data: { sort: newSort[0].field, 'sort-order': newSort[0].order } };
 }

--- a/src/services/search/search_reducer.js
+++ b/src/services/search/search_reducer.js
@@ -54,7 +54,7 @@ export default function searchReducer(state, action) {
       return {
         ...state,
         sort: action.data.sort,
-        sort_order: action.data.sort_order,
+        'sort-order': action.data.sort-order,
       };
     case 'UPDATE_SORT_ONLY':
       return {
@@ -64,7 +64,7 @@ export default function searchReducer(state, action) {
     case 'UPDATE_SORT_ORDER':
       return {
         ...state,
-        sort_order: action.data.sort_order,
+        'sort-order': action.data['sort-order'],
       };
     case 'UPDATE_FULLTEXT':
       return {

--- a/src/services/search/search_reducer.js
+++ b/src/services/search/search_reducer.js
@@ -54,7 +54,7 @@ export default function searchReducer(state, action) {
       return {
         ...state,
         sort: action.data.sort,
-        'sort-order': action.data.sort-order,
+        'sort-order': action.data['sort-order'],
       };
     case 'UPDATE_SORT_ONLY':
       return {


### PR DESCRIPTION
CivicActions' data-catalog-components package uses sort_order internally to keep track of how the results will be ordered (date, alphabetical...). When it's finally used to craft a URL to query the backend, the string query should contain sort-order with a dash instead of an underscore, to be more consistent with the other sorting parameters like page-size.