### PR TITLE
Fix search page resetting to page 1 on fresh load

### DIFF
--- a/src/components/Search/index.jsx
+++ b/src/components/Search/index.jsx
@@ -51,9 +51,7 @@ const Search = ({
 
     urlOptions.forEach((param) => {
       if (params[param]) {
-        const data = {};
-        data[param] = params[param];
-
+        const data = params;
         dispatched = true;
         dispatch({
           type: actions[param],
@@ -72,6 +70,7 @@ const Search = ({
             type: 'UPDATE_FACETS',
             data: {
               newFacet,
+              page: params.page
             },
           });
         });

--- a/src/components/SearchInput/index.jsx
+++ b/src/components/SearchInput/index.jsx
@@ -29,7 +29,9 @@ const SearchInput = ({
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      onChangeFunction({ type: 'UPDATE_FULLTEXT', data: { fulltext: searchQuery } });
+      if(searchQuery !== value) {
+        onChangeFunction({ type: 'UPDATE_FULLTEXT', data: { fulltext: searchQuery, page: 1 } });
+      }
     }, 500);
     return () => clearTimeout(timer);
   }, [searchQuery, onChangeFunction]);

--- a/src/services/search/search_reducer.js
+++ b/src/services/search/search_reducer.js
@@ -14,7 +14,7 @@ export function updateSelectedFacetsState(state, action) {
   return {
     ...state,
     selectedFacets: newSelectedFacets,
-    page: 1,
+    page: action.data.page || 1,
   };
 }
 
@@ -70,13 +70,13 @@ export default function searchReducer(state, action) {
       return {
         ...state,
         fulltext: action.data.fulltext,
-        page: 1,
+        page: action.data.page || 1,
       };
     case 'UPDATE_PAGE_SIZE':
       return {
         ...state,
         'page-size': action.data['page-size'],
-        page: 1,
+        page: action.data.page || 1,
       };
     case 'UPDATE_CURRENT_PAGE':
       return {
@@ -94,7 +94,7 @@ export default function searchReducer(state, action) {
       return {
         ...state,
         selectedFacets: action.data.selectedFacets,
-        page: 1,
+        page: action.data.page || 1,
       };
     case 'RESET_ALL':
       return {


### PR DESCRIPTION
This PR updates the Search component and reducer to only set page to 1 if no action.data.page is passed through. Normally when making an update we should reset to 1, but on a fresh load the page should also be set but some of the other reducers were being fired which set the page back to 1. 