### PR TITLE
Add li around SearchListItems

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/data-catalog-components",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "React Components for Open Data Catalogs.",
   "main": "lib/index.js",
   "repository": {

--- a/src/components/TopicWrapper/index.jsx
+++ b/src/components/TopicWrapper/index.jsx
@@ -17,7 +17,7 @@ const TopicWrapper = ({ component, topic }) => {
 };
 
 TopicWrapper.propTypes = {
-  component: PropTypes.string.isRequired,
+  component: PropTypes.func.isRequired,
   topic: PropTypes.string.isRequired,
 };
 export default TopicWrapper;

--- a/src/templates/SearchContent/index.jsx
+++ b/src/templates/SearchContent/index.jsx
@@ -47,8 +47,8 @@ const SearchContent = () => {
           >
             <ol>
               {items.map((item) => (
-                <li>
-                  <SearchListItem key={item.identifier} item={item} />
+                <li key={item.identifier}>
+                  <SearchListItem item={item} />
                 </li>
               ))}
             </ol>

--- a/src/templates/SearchContent/index.jsx
+++ b/src/templates/SearchContent/index.jsx
@@ -47,7 +47,9 @@ const SearchContent = () => {
           >
             <ol>
               {items.map((item) => (
-                <SearchListItem key={item.identifier} item={item} />
+                <li>
+                  <SearchListItem key={item.identifier} item={item} />
+                </li>
               ))}
             </ol>
           </Loader>


### PR DESCRIPTION
In the SearchListContent template we render all the items in an ordered list. The SearchListItem returns a div so the final result was an ordered list with div as children. This PR just wraps each item in a list item tag to fix an accessibility issue. 