### PR TITLE
Check node version in ci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
       - run:
           name: Run cypress tests
           command: |
+            nvm install 10
             mkdir ~/sandbox
             cd ~/sandbox
             dktl init

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
             dktl frontend:install
             git clone --single-branch -b $CIRCLE_BRANCH https://github.com/GetDKAN/data-catalog-components.git
             cd ~/sandbox/data-catalog-components
+            node -v
             npm install --unsafe-perms
             npm pack --unsafe-perm
             filename=`ls ./ | grep tgz`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,6 @@ jobs:
             dktl frontend:install
             git clone --single-branch -b $CIRCLE_BRANCH https://github.com/GetDKAN/data-catalog-components.git
             cd ~/sandbox/data-catalog-components
-            node -v
             npm install --unsafe-perms
             npm pack --unsafe-perm
             filename=`ls ./ | grep tgz`


### PR DESCRIPTION
We are using `circleci/classic:latest` as the machine image on all of the DKAN projects I believe. Within the builds we use a Docker container using a newer version of node. In the Jest tests I already had an `nvm` process to update the node version to 10 so it would run Jest correctly. It looks like something has updated in the rest of our code that requires more than the node 6 that comes with `circleci/classic:latest` so when we did the `npm install` and `npm pack` outside the DKAN containers the process was failing. 