### PR TITLE
Fix datatables when no results found

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/data-catalog-components",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "React Components for Open Data Catalogs.",
   "main": "lib/index.js",
   "repository": {

--- a/src/templates/DataTable/index.jsx
+++ b/src/templates/DataTable/index.jsx
@@ -45,7 +45,7 @@ const DataTable = () => {
     }
   }, [resourceState.store, filters]);
 
-  if (!reactTable.data.length) {
+  if (!reactTable.columns.length) {
     return null;
   }
 
@@ -103,6 +103,12 @@ const DataTable = () => {
           ))}
         </div>
         <div {...getTableBodyProps()} className="dc-tbody">
+          {page.length <= 0
+            &&(
+            <div className="tr dc-tr" style={{textAlign: 'center'}}>
+              No results found.
+            </div>)
+          }
           {page.map((row) => {
             prepareRow(row);
             return (

--- a/src/templates/DataTableHeader/index.jsx
+++ b/src/templates/DataTableHeader/index.jsx
@@ -9,7 +9,7 @@ import DataIcon from '../../components/DataIcon';
 const DataTableHeader = () => {
   const { reactTable, resourceState, dispatch } = React.useContext(ResourceDispatch);
 
-  if (!reactTable.data.length) {
+  if (!reactTable.columns.length) {
     return null;
   }
   return (


### PR DESCRIPTION
This along with the linked App pull request address issues in #81 .

- Show 'no result found' message rather than lose access to the table.
- keep row data from wrapping by adding ... when it overruns the column width (seems to be fixed already)
- zebra striping does not carry through when scrolling to the right
https://github.com/GetDKAN/data-catalog-app/pull/53