### PR TITLE
Swap React Strap for USWDS

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "reactstrap": "^7.1.0",
     "styled-components": "^5.0.1",
     "swagger-ui-react": "3.25.0",
+    "uswds": "^2.10.0",
     "validator": "^12.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This work will run parallel with https://github.com/GetDKAN/data-catalog-app/pull/54 where we move from React strap to USWDS as the primary design system. This will have backward incompatible changes in terms of styling, so it will be a new release. 