### PR TITLE
Fix storybook so scss files work

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   "stories": [
     "../src/**/*.stories.mdx",
@@ -6,5 +8,20 @@ module.exports = {
   "addons": [
     "@storybook/addon-links",
     "@storybook/addon-essentials"
-  ]
-}
+  ],
+  webpackFinal: async (config, { configType }) => {
+    // `configType` has a value of 'DEVELOPMENT' or 'PRODUCTION'
+    // You can change the configuration based on that.
+    // 'PRODUCTION' is used when building the static version of storybook.
+
+    // Make whatever fine-grained changes you need
+    config.module.rules.push({
+      test: /\.scss$/,
+      use: ['style-loader', 'css-loader', 'sass-loader'],
+      include: path.resolve(__dirname, '../'),
+    });
+
+    // Return the altered config
+    return config;
+  },
+};

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,3 @@
-import '!style-loader!css-loader!sass-loader!../src/stories/styles.scss';
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
 }

--- a/src/components/Card/Card.stories.mdx
+++ b/src/components/Card/Card.stories.mdx
@@ -1,0 +1,20 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import Card from './index';
+
+<Meta title="USWDS/Card" component={Card} />
+
+# Card
+
+<Canvas>
+    <Story name="Basic">
+      <ul className="usa-card-group">
+        <Card
+          headingText="Card Title"
+          bodyText="This is the card body."
+          buttonText="Click me"
+          media={<img src="https://s3.amazonaws.com/dkan-default-content-files/files/group.png" alt="default logo" />}
+          buttonAction={() => (console.log("Clicked"))}
+        />
+      </ul>
+    </Story>
+</Canvas>


### PR DESCRIPTION
Instead of just adding some loaders during the preview build, I copied the Webpack settings from the Storybook docs and put them in the module exports in main.js

To test, I have included a very basic story for Card component that uses USWDS classes. Just pull the code, install node modules and run `npm run storybook` and checkout the Card component. 