### PR TITLE
Add new DynamicLink component to handle external/internal links

### DIFF
--- a/src/components/DynamicLink/DynamicLink.stories.mdx
+++ b/src/components/DynamicLink/DynamicLink.stories.mdx
@@ -1,0 +1,23 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import DynamicLink from './index';
+
+<Meta title="Dynamic Link" component={DynamicLink} />
+
+# Dynamic Link
+This component creates a link that will be a Reach Router component if internal and a basic `a` tag if external.
+
+<Canvas>
+    <Story name="External">
+      <DynamicLink
+        url="https://demo.getdkan.org"
+        content="Demo site"
+        cue={<span> (external link)</span>}
+      />
+    </Story>
+    <Story name="Internal">
+      <DynamicLink
+        url="/?path=/story/dynamic-link--external"
+        content="External Link"
+      />
+    </Story>
+</Canvas>

--- a/src/components/DynamicLink/dynamiclink.test.jsx
+++ b/src/components/DynamicLink/dynamiclink.test.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import DynamicLink from './index';
+
+describe('<DynamicLink />', () => {
+  test('renders external link', async () => {
+    render(
+      <DynamicLink
+        url='https://demo.getdkan.org'
+        content='Demo site'
+      />
+    )
+
+    expect(screen.getByRole('link', {name: 'Demo site'})).toBeInTheDocument();
+  })
+  test('renders external link with cue', async () => {
+    render(
+      <DynamicLink
+        url='https://demo.getdkan.org'
+        content='Demo site'
+        cue=" (external)"
+      />
+    )
+
+    expect(screen.getByRole('link', {name: 'Demo site (external)'})).toBeInTheDocument();
+  })
+  test('renders a link', async () => {
+    render(
+      <DynamicLink
+        url='/about'
+        content='About'
+      />
+    )
+
+    expect(screen.getByRole('link', {name: 'About'})).toBeInTheDocument();
+  })
+});

--- a/src/components/DynamicLink/index.jsx
+++ b/src/components/DynamicLink/index.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from '@reach/router';
+import validator from 'validator';
+
+const DynamicLink = ({url, content, cue}) => {
+  if(validator.isURL(url, { require_protocol: true })) {
+    return (
+      <a
+        className={''}
+        href={url}
+      >
+        {content}
+        {cue
+          && (
+            cue
+          )
+        }
+      </a>
+    )
+  }
+  return(
+    <Link
+      className={''}
+      to={url}
+    >
+      {content}
+    </Link>
+  );
+}
+
+DynamicLink.defaultProps = {
+  cue: undefined,
+}
+
+DynamicLink.propTypes = {
+  url: PropTypes.string.isRequired,
+  content: PropTypes.node.isRequired,
+  cue: PropTypes.node,
+}
+
+export default DynamicLink;


### PR DESCRIPTION
This replaces something called NavLink in CMSDS open data components. This component can be used when doing `.maps` or other automated feature to make sure React Router is only used on internal links. 