### PR TITLE
Fix PropTypes and add test to APIDocs

### DIFF
--- a/src/components/ApiDocs/apidocs.test.jsx
+++ b/src/components/ApiDocs/apidocs.test.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import ApiDocs from './index';
+
+
+describe('<ApiDocs />', () => {
+
+  beforeAll(() => jest.spyOn(window, 'fetch'))
+
+  test('builds base url correctly', async () => {
+    render(<ApiDocs endpoint="http://dkan.org" />);
+    await act(async () => {  });
+    expect(window.fetch).toHaveBeenCalledWith(
+      'http://dkan.org?authentication=false',
+      expect.objectContaining({
+        url: 'http://dkan.org?authentication=false',
+      }),
+    )
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  test('builds base url correctly with authentication', async () => {
+    render(<ApiDocs endpoint="http://dkan.org" authentication={true} />);
+    await act(async () => {  });
+    expect(window.fetch).toHaveBeenCalledWith(
+      'http://dkan.org?authentication=true',
+      expect.objectContaining({
+        url: 'http://dkan.org?authentication=true',
+      }),
+    )
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  test('builds dataset url correctly', async () => {
+    render(<ApiDocs endpoint="http://dkan.org" datasetID={12345} />);
+    await act(async () => {  });
+    expect(window.fetch).toHaveBeenCalledWith(
+      'http://dkan.org/metastore/schemas/dataset/items/12345/docs',
+      expect.objectContaining({
+        url: 'http://dkan.org/metastore/schemas/dataset/items/12345/docs',
+      }),
+    )
+    expect(window.fetch).toHaveBeenCalledTimes(1)
+  })
+});

--- a/src/components/ApiDocs/apidocs.test.jsx
+++ b/src/components/ApiDocs/apidocs.test.jsx
@@ -32,7 +32,7 @@ describe('<ApiDocs />', () => {
   })
 
   test('builds dataset url correctly', async () => {
-    render(<ApiDocs endpoint="http://dkan.org" datasetID={12345} />);
+    render(<ApiDocs endpoint="http://dkan.org" datasetID={'12345'} />);
     await act(async () => {  });
     expect(window.fetch).toHaveBeenCalledWith(
       'http://dkan.org/metastore/schemas/dataset/items/12345/docs',

--- a/src/components/ApiDocs/apidocs.test.jsx
+++ b/src/components/ApiDocs/apidocs.test.jsx
@@ -18,7 +18,6 @@ describe('<ApiDocs />', () => {
         url: 'http://dkan.org?authentication=false',
       }),
     )
-    expect(window.fetch).toHaveBeenCalledTimes(1)
   })
 
   test('builds base url correctly with authentication', async () => {
@@ -30,7 +29,6 @@ describe('<ApiDocs />', () => {
         url: 'http://dkan.org?authentication=true',
       }),
     )
-    expect(window.fetch).toHaveBeenCalledTimes(1)
   })
 
   test('builds dataset url correctly', async () => {
@@ -42,6 +40,5 @@ describe('<ApiDocs />', () => {
         url: 'http://dkan.org/metastore/schemas/dataset/items/12345/docs',
       }),
     )
-    expect(window.fetch).toHaveBeenCalledTimes(1)
   })
 });

--- a/src/components/ApiDocs/index.jsx
+++ b/src/components/ApiDocs/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SwaggerUI from 'swagger-ui-react';
-// import 'swagger-ui-react/swagger-ui.css';
 
 const ApiDocs = ({ endpoint, datasetID, authentication, expansion }) => {
 
@@ -10,9 +9,7 @@ const ApiDocs = ({ endpoint, datasetID, authentication, expansion }) => {
     url = `${endpoint}/metastore/schemas/dataset/items/${datasetID}/docs`
   }
 
-  return typeof window === 'undefined'
-    ? null
-    : <SwaggerUI url={url} docExpansion={expansion} />;
+  return <SwaggerUI url={url} docExpansion={expansion} />;
 };
 
 ApiDocs.defaultProps = {
@@ -25,7 +22,7 @@ ApiDocs.propTypes = {
   endpoint: PropTypes.string.isRequired,
   authentication: PropTypes.bool,
   datasetID: PropTypes.string,
-  expansion: PropTypes.oneOf['list', 'full', 'none'],
+  expansion: PropTypes.oneOf(['list', 'full', 'none']),
 };
 
 export default ApiDocs;


### PR DESCRIPTION
This just adds some basic tests to make sure the Swagger url prop is being build properly. It doesn't test anything about what Swagger returns. 