### PR TITLE
DataTable updates 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/data-catalog-components",
-  "version": "2.0.0-alpha.9",
+  "version": "2.0.0-beta.1",
   "description": "React Components for Open Data Catalogs.",
   "private": false,
   "main": "dist/index.cjs.js",

--- a/src/components/DataTable/DataTablePageResults/index.jsx
+++ b/src/components/DataTable/DataTablePageResults/index.jsx
@@ -4,9 +4,13 @@ import PropTypes from 'prop-types';
 const DataTablePageResults = ({
   totalRows, limit, offset, className
 }) => {
-  const numTotalRows = parseInt(totalRows)
+  const numTotalRows = parseInt(totalRows);
+  if (numTotalRows === 0) {
+    return <p className={className}>{`0 - 0 of 0 rows`}</p>
+  }
   const ofTotal = () => {
     if (limit >= numTotalRows) { return numTotalRows; }
+    if (limit + offset >= numTotalRows) { return numTotalRows; }
     if (offset === 0) { return limit; }
     return (offset + limit);
   }

--- a/src/components/DataTable/DataTablePageResults/index.jsx
+++ b/src/components/DataTable/DataTablePageResults/index.jsx
@@ -17,7 +17,7 @@ const DataTablePageResults = ({
   const page = offset / limit;
   const startTotal = () => (page * limit + 1)
   return (
-    <p className={className}>{`${startTotal()} - ${ofTotal()} of ${numTotalRows.toLocaleString()} rows`}</p>
+    <p className={className}>{`${startTotal().toLocaleString()} - ${ofTotal().toLocaleString()} of ${numTotalRows.toLocaleString()} rows`}</p>
   );
 };
 

--- a/src/components/DataTable/index.jsx
+++ b/src/components/DataTable/index.jsx
@@ -18,7 +18,9 @@ const DataTable = ({
   className,
   tableClasses,
   customColumnFilter,
-  cellTextClassName
+  cellTextClassName, 
+  CustomLoadingComponent,
+  CustomNoResults,
 }) => {
   const { layout, columnFilter, columnSort, columnResize } = options;
   const { minWidth, maxWidth, width } = columnDefaults
@@ -227,33 +229,43 @@ const DataTable = ({
           )}
       </div>
       <div className="tbody">
-        {rows.map((row, index) => {
-          const even = (index + 1) % 2 === 0;
-          prepareRow(row)
-          let classList = cellClassName
-          if (index === 0 && cellFirstRowClassName) {
-            classList = cellFirstRowClassName
-          }
-          if (even) {
-            classList += ` ${cellEvenRowClassName}`
-          }
-          if (!even) {
-            classList += ` ${cellOddRowClassName}`
-          }
-          return (
-            <div {...row.getRowProps()} className="tr">
-              {row.cells.map((cell) => {
-                return (
-                  <div {...cell.getCellProps()} className={classList}>
-                    <span className={cellTextClassName}>
-                      {cell.render('Cell')}
-                    </span>
-                  </div>
-                )
-              })}
-            </div>
+        {loading
+          ? (CustomLoadingComponent ? CustomLoadingComponent : <p>Loading...</p>)
+          : (
+            rows.length
+              ? (
+                rows.map((row, index) => {
+                  const even = (index + 1) % 2 === 0;
+                  prepareRow(row)
+                  let classList = cellClassName
+                  if (index === 0 && cellFirstRowClassName) {
+                    classList = cellFirstRowClassName
+                  }
+                  if (even) {
+                    classList += ` ${cellEvenRowClassName}`
+                  }
+                  if (!even) {
+                    classList += ` ${cellOddRowClassName}`
+                  }
+                  return (
+                    <div {...row.getRowProps()} className="tr">
+                      {row.cells.map((cell) => {
+                        return (
+                          <div {...cell.getCellProps()} className={classList}>
+                            <span className={cellTextClassName}>
+                              {cell.render('Cell')}
+                            </span>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  )
+                })
+              ) : (
+                CustomNoResults ? CustomNoResults : <p>No results found.</p>
+              )
           )
-        })}
+        }
       </div>
     </div>
   )


### PR DESCRIPTION
This PR adds some missing loading and no result features to the DataTable and DataTableResults section. 

The DataTable gets 2 additional props and uses the loading state to show/hide the rows. The additional props allow for new components to be passed through to replace the default loading/no results jsx. 

For the DataTablePageResults components there are two fixes:

1. When on the last page of a dataset results, the limit was always applied to the offset, which could result in the display showing 11-20 out of 17. It will now show the total results if limit + offset is greater than total.
2. When no total is passed, it will return 0-0 of 0 rows instead of 1-0 of 0 rows. 