### PR TITLE
Replace Reach Router with React Router v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "axios": "^0.21.1",
     "bootstrap": "^4.2.1",
     "excerpts": "0.0.3",
+    "history": "^5.3.0",
     "html-to-react": "^1.3.4",
     "immutability-helper": "^3.0.2",
     "lodash": "^4.17.15",
@@ -51,6 +52,7 @@
     "react-js-pagination": "^3.0.2",
     "react-loader-advanced": "^1.7.1",
     "react-loading-spin": "^1.0.9",
+    "react-router-dom": "^6.3.0",
     "react-table": "^7.0.4",
     "reactstrap": "^7.1.0",
     "styled-components": "^5.0.1",
@@ -120,7 +122,6 @@
     "jest": "^24.9.0",
     "node-sass": "^4.13.1",
     "prettier": "^1.16.0",
-    "react-router-dom": "^4.3.1",
     "react-test-renderer": "^16.9.0",
     "sass-loader": "^7.1.0",
     "url-loader": "^1.1.2"

--- a/src/components/IconListItem/index.jsx
+++ b/src/components/IconListItem/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from '@reach/router';
+import { Link } from 'react-router-dom';
 import TopicIcon from '../../templates/TopicIcon';
 
 function IconListItem({

--- a/src/components/IconListItem/index.test.jsx
+++ b/src/components/IconListItem/index.test.jsx
@@ -1,11 +1,18 @@
 import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import IconListItem from './index';
 
 describe('<IconListItem />', () => {
   test('renders a title', () => {
-    render(<IconListItem link="http://demo.getdkan.com" title="dkan" />);
+    const history = createMemoryHistory();
+    render(
+      <BrowserRouter history={history}>
+        <IconListItem link="http://demo.getdkan.com" title="dkan" />
+      </BrowserRouter>,
+    );
     expect(screen.getByText('dkan')).toBeInTheDocument();
   });
 });

--- a/src/components/Logo/index.jsx
+++ b/src/components/Logo/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from '@reach/router';
+import { Link } from 'react-router-dom';
 
 const Logo = ({ image }) => (
   <Link to="/" className="dc-logo">

--- a/src/components/SearchListItem/index.jsx
+++ b/src/components/SearchListItem/index.jsx
@@ -5,7 +5,7 @@ import excerpts from 'excerpts';
 import TopicIcon from '../../templates/TopicIcon';
 import DataIcon from '../DataIcon';
 import Text from '../Text';
-import { Link } from '@reach/router';
+import { Link } from 'react-router-dom';
 import {countBy} from 'lodash';
 
 

--- a/src/components/SearchListItem/index.test.jsx
+++ b/src/components/SearchListItem/index.test.jsx
@@ -1,20 +1,25 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 import '@testing-library/jest-dom/extend-expect';
-import SearchListItem, {getUniqueFormats} from './index';
+import SearchListItem, { getUniqueFormats} from './index';
 
 describe('<SearchListItem />', () => {
 
   test('renders an item', () => {
+    const history = createMemoryHistory();
 
-    render(<SearchListItem
-             item={
-               {
-                 title: 'dkan',
-                 ref: '/dkan-item',
-               }
-             }
-           />);
+    render(
+      <BrowserRouter history={history}>
+        <SearchListItem
+          item={{
+            title: 'dkan',
+            ref: '/dkan-item',
+          }}
+        />
+      </BrowserRouter>,
+    );
     expect(screen.getByRole('heading', 'Welcome to DKAN')).toBeInTheDocument();
   });
 
@@ -59,38 +64,30 @@ describe('<SearchListItem />', () => {
       ]);
   });
 
-  test('Return formats with count.',() => {
+  test('Return formats with count.', () => {
+    const history = createMemoryHistory();
     render(
-      <SearchListItem
-        item={
-          {
-            title: 'dkan',
-            ref: '/dkan-item',
+      <BrowserRouter history={history}>
+        <SearchListItem
+          item={{
+            title: "dkan",
+            ref: "/dkan-item",
             format: [
-              {"format": "csv",
-               "identifier": 1
-              },
-              {"format": "csv",
-               "identifier": 2
-              },
-              {"format": "csv",
-               "identifier": 3
-              },
-              {"format": "rdf",
-               "identifier": 4
-              },
-              {"format": "xml",
-               "identifier": 5
-              }
+              { format: "csv", identifier: 1 },
+              { format: "csv", identifier: 2 },
+              { format: "csv", identifier: 3 },
+              { format: "rdf", identifier: 4 },
+              { format: "xml", identifier: 5 }
             ],
-            theme: ['category'],
-            identifier: '123',
-            ref: '/',
-            description: 'This is the description.',
-            publisher: 'Data Provider Name',
-          }
-        }
-      />);
+            theme: ["category"],
+            identifier: "123",
+            ref: "/",
+            description: "This is the description.",
+            publisher: "Data Provider Name"
+          }}
+        />
+      </BrowserRouter>,
+    );
 
     expect(screen.getByText('1x rdf')).toBeInTheDocument();
     expect(screen.getByText('1x xml')).toBeInTheDocument();

--- a/src/components/TopicWrapper/index.jsx
+++ b/src/components/TopicWrapper/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from '@reach/router';
+import { Link } from 'react-router-dom';
 
 const TopicWrapper = ({ component, topic }) => {
   const ComponentToRender = component;

--- a/src/components/TopicWrapper/index.test.jsx
+++ b/src/components/TopicWrapper/index.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { BrowserRouter } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import TopicWrapper from './index';
@@ -9,7 +11,12 @@ TestComponent.propTypes = { title: PropTypes.string.isRequired };
 
 describe('<TopicWrapper />', () => {
   test('renders with component in link', () => {
-    render(<TopicWrapper topic="dkan" component={TestComponent} />);
+    const history = createMemoryHistory();
+    render(
+      <BrowserRouter history={history}>
+        <TopicWrapper topic="dkan" component={TestComponent} />
+      </BrowserRouter>,
+    );
     expect(screen.getByRole('link')).toHaveClass('dc-topic-wrapper');
     expect(screen.getByRole('link')).toContainHTML('<div class="dkan">Test Component</div>dkan');
     expect(screen.getByText('dkan'));

--- a/src/templates/Blocks/BasicBlock.jsx
+++ b/src/templates/Blocks/BasicBlock.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from '@reach/router';
+import { Link } from 'react-router-dom';
 import Text from '../../components/Text';
 
 class BasicBlock extends React.PureComponent {

--- a/src/templates/Blocks/index.test.jsx
+++ b/src/templates/Blocks/index.test.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import Blocks from './index';
@@ -8,14 +10,21 @@ import StepsBlock from './StepsBlock';
 
 describe('<Blocks />', () => {
   test('renders a heading by default', () => {
-    render(<Blocks paneTitle="Welcome to DKAN" items={[{ title: 'Welcome to DKAN', ref: '/dkan' }]} />);
+    render(
+      <Blocks paneTitle="Welcome to DKAN" items={[{ title: 'Welcome to DKAN', ref: '/dkan' }]} />
+    );
     expect(screen.getByRole('heading', 'Welcome to DKAN')).toBeInTheDocument();
   });
 });
 
 describe('<BasicBlock />', () => {
   test('renders a heading by default', () => {
-    render(<BasicBlock content={{ title: 'Welcome to DKAN', ref: '/dkan' }} />);
+    const history = createMemoryHistory();
+    render(
+      <BrowserRouter history={history}>
+        <BasicBlock content={{ title: 'Welcome to DKAN', ref: '/dkan' }} />
+      </BrowserRouter>,
+    );
     expect(screen.getByRole('heading', 'Welcome to DKAN')).toBeInTheDocument();
   });
 });

--- a/src/templates/Header/index.jsx
+++ b/src/templates/Header/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from '@reach/router';
+import { Link } from 'react-router-dom';
 import NavBar from '../NavBar';
 
 const Header = ({

--- a/src/templates/Header/index.test.jsx
+++ b/src/templates/Header/index.test.jsx
@@ -1,11 +1,18 @@
 import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import Header from './index';
 
 describe('<Header />', () => {
   test('renders a logo by default', () => {
-    render(<Header />);
+    const history = createMemoryHistory();
+    render(
+      <BrowserRouter history={history}>
+        <Header />
+      </BrowserRouter>,
+    );
     expect(screen.getByAltText('Open Data Catalog')).toBeInTheDocument();
   });
 });

--- a/src/templates/Hero/index.jsx
+++ b/src/templates/Hero/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { navigate } from '@reach/router';
+import { useNavigate } from 'react-router-dom';
 import { Input, Label, Button } from 'reactstrap';
 
 const Hero = ({
@@ -14,6 +14,7 @@ const Hero = ({
   gradient,
 }) => {
   const [query, setQuery] = useState('');
+  const navigate = useNavigate();
   const background = image
     ? `url(${image})`
     : `linear-gradient(${gradient})`;

--- a/src/templates/Hero/index.test.jsx
+++ b/src/templates/Hero/index.test.jsx
@@ -1,11 +1,18 @@
 import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import Hero from './index';
 
 describe('<Hero />', () => {
   test('renders a heading by default', () => {
-    render(<Hero />);
+    const history = createMemoryHistory();
+    render(
+      <BrowserRouter history={history}>
+        <Hero />
+      </BrowserRouter>,
+    );
     expect(screen.getByRole('heading', 'Welcome to DKAN')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Reach Router and it’s sibling project React Router have merged as React Router v6.
Components, templates and tests have been migrated from Reach Router v1 to React Router v6.

This will also allow us to use more recent React versions.