### PR TITLE
Add sortDefaults to datatable to fix initial useEffect reseting sort

### DIFF
--- a/src/components/DataTable/index.jsx
+++ b/src/components/DataTable/index.jsx
@@ -19,6 +19,7 @@ const DataTable = ({
   loading,
   options,
   columnDefaults,
+  sortDefaults,
   setSort,
   setConditions,
   conditionsTransform,
@@ -122,7 +123,9 @@ const DataTable = ({
       columns,
       data,
       filterTypes,
-      initialState: {},
+      initialState: {
+        sortBy: sortDefaults
+      },
       manualPagination: true,
       manualFilters: true,
       manualSortBy: true,
@@ -136,7 +139,6 @@ const DataTable = ({
     usePagination,
     layout === "block" ? useBlockLayout : useFlexLayout
   );
-
   useEffect(() => {
     if (columnSort) {
       const normalizedSort = sortTransform ? sortTransform(sortBy) : filters;
@@ -317,6 +319,7 @@ DataTable.propTypes = {
     columnSort: PropTypes.bool,
     columnResize: PropTypes.bool,
   }),
+  sortDefaults: [],
   columns: PropTypes.arrayOf(
     PropTypes.shape({
       Header: PropTypes.string.isRequired,


### PR DESCRIPTION
If a datatable was mounted that had an initial sort this was lost after the useEffects first pass. This wouldn't show on the until the data was updated, through something like pagination change. The setSort in the component would pass the blank sortBy state from the react-table back to the Resource prop. This update allows for a custom default sort to be passed to react-table on initialization to stop this from happening. 